### PR TITLE
Add 51 and 110 error codes

### DIFF
--- a/lib/src/network_analyzer.dart
+++ b/lib/src/network_analyzer.dart
@@ -110,12 +110,14 @@ class NetworkAnalyzer {
 
   // 13: Connection failed (OS Error: Permission denied)
   // 49: Bind failed (OS Error: Can't assign requested address)
+  // 51: Network is unreachable
   // 61: OS Error: Connection refused
   // 64: Connection failed (OS Error: Host is down)
   // 65: No route to host
   // 101: Network is unreachable
+  // 110: Connection timed out
   // 111: Connection refused
   // 113: No route to host
   // <empty>: SocketException: Connection timed out
-  static final _errorCodes = [13, 49, 61, 64, 65, 101, 111, 113];
+  static final _errorCodes = [13, 49, 51, 61, 64, 65, 101, 110, 111, 113];
 }


### PR DESCRIPTION
Add these error codes to predefined `_errorCodes`

- 51: Network is unreachable
- 110: Connection timed out